### PR TITLE
スプレッドシートのIDを env ファイルから呼び出すようにした #9

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ scraping_credentials.json
 __pycache__/
 *.pyo
 *.pyd
+.env

--- a/manually_copied_from_Windows/dist/scraper.exe
+++ b/manually_copied_from_Windows/dist/scraper.exe
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:0c4936c34210e85f787ad92cc4b42c0e46240369aef4d41778604b63d51c57ae
+oid sha256:890a114dca36a0bfeee4d3f63eeee0bf09ba8615a96e4c4be0cfb7925f4e4b2c
 size 55899821

--- a/manually_copied_from_Windows/dist/send_to_sheets.exe
+++ b/manually_copied_from_Windows/dist/send_to_sheets.exe
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1256095e617c24f5e47fef1a4eda14133ba7d9d6d0a9a83beed3cf8c238b8184
-size 59197168
+oid sha256:69dd5f964101ff7398ca1e449c536935220ac0105aefc469886472cfdcba46bc
+size 59215325

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ google-auth-oauthlib
 google-auth-httplib2
 google-api-python-client
 oauth2client
+python-dotenv

--- a/send_to_sheets.py
+++ b/send_to_sheets.py
@@ -5,6 +5,14 @@ from google.oauth2 import service_account
 # この関数を使用して、Google Sheets APIを構築します。
 from googleapiclient.discovery import build
 
+# 環境変数を読み込む
+from dotenv import load_dotenv  
+# osモジュールを使用して環境変数を読み込む
+import os
+
+# .envファイルを読み込む
+load_dotenv()
+
 # Google Sheets APIの設定
 # 読み取り専用のアクセスが必要な場合、
 # スコープをhttps://www.googleapis.com/auth/spreadsheets.readonlyに変更
@@ -17,7 +25,10 @@ creds = service_account.Credentials.from_service_account_file(
         SERVICE_ACCOUNT_FILE, scopes=SCOPES)
 
 # 使用するスプレッドシートのIDと範囲を設定
-SPREADSHEET_ID = '1bX63acuqzf3yQ-oF6QTEyybcg52wjh5gC78wvIWDdq0'
+# SPREADSHEET_ID = '1bXXXXXXXXXXXXXXXXXXXXXXXXXXXX'
+# 環境変数を取得する
+SPREADSHEET_ID = os.getenv('SPREADSHEET_ID')
+
 
 RANGE_NAME = 'Sheet1!A1'
 


### PR DESCRIPTION
- .env ファイルを作成した
   -  SPREADSHEET_ID を追加した
-  requirements.txt に python-dotenv を追加した
   - dockerfile でも呼び出している 
- .gitignore に .env を追加した
- send_to_sheets.py の SPREADSHEET_ID は .env から呼び出すようにした
- exe ファイルを生成する際に --hidden-import=python_dotenv を追加した
   -  `pyinstaller --onefile --hidden-import=python_dotenv --add-binary="C:\\Users\\pc-XXX\\Desktop\\SBI#9_manage_credentials\\dist\\chromedriver.exe;." \\wsl$\\Ubuntu\\home\\XXX\\scraping-work\\send_to_sheets.py`